### PR TITLE
ruby-devel required for OpenSuse

### DIFF
--- a/docs/_docs/installation/other-linux.md
+++ b/docs/_docs/installation/other-linux.md
@@ -47,6 +47,7 @@ sudo pacman -S ruby base-devel
 
 ```sh
 sudo zypper install -t pattern devel_ruby devel_C_C++
+sudo zypper install ruby-devel
 ```
 
 ### Clear Linux


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary
OpenSUSE requires `ruby-devel`, which is not covered by the existing distro-specific install docs.

## Context
Initially raised in https://github.com/jekyll/jekyll/issues/8118, this issue is still outstanding.

## Caveats
On OpenSUSE Tumbleweed (in April '21), following these install instructions to the letter will add `jekyll.ruby2.7*` to PATH, rather than `jekyll`. Users must either use the unwieldy  `jekyll.ruby2.7 serve` (etc),  or consider adding a bash alias or symlink so that `jekyll serve` works as expected.
